### PR TITLE
Limit log history and persist reload counter

### DIFF
--- a/earlier-time.user.js
+++ b/earlier-time.user.js
@@ -38,6 +38,7 @@
   // 予約失敗時の復旧リロード 最大回数（秒に関係なく実施）
   const MAX_ATTEMPTS_PER_MINUTE = 3;
   const ATTEMPT_STORAGE_KEY = 'expo_adv_attempt_info_v3';
+  const RELOAD_STORAGE_KEY = 'expo_adv_reload_info_v1';
 
   // トグル保存キー
   const ENABLE_KEY = 'expo_adv_enable_v2';
@@ -78,6 +79,28 @@
     } catch {
       // storage full or unavailable
     }
+  }
+
+  function loadReloadInfo() {
+    try {
+      return JSON.parse(sessionStorage.getItem(RELOAD_STORAGE_KEY) || '{}');
+    } catch {
+      return {};
+    }
+  }
+
+  function saveReloadInfo(info) {
+    try {
+      sessionStorage.setItem(RELOAD_STORAGE_KEY, JSON.stringify(info));
+    } catch {
+      // storage full or unavailable
+    }
+  }
+
+  function resetReloadInfo(bucket) {
+    const info = { bucket, count: 0, loggedMinute: null };
+    saveReloadInfo(info);
+    return info;
   }
 
   async function registerAttempt() {
@@ -149,12 +172,12 @@
   }
 
   /***** リロード制御（サーバー時刻ベース） *****/
-  let lastMinute = null;
   let reloadsThisMinute = 0;
   let ticking = false;
   let stopped = false;
   let pendingReload = false;
   let attemptBlockedUntil = 0;
+  let reloadInfo = loadReloadInfo();
 
   // 予約変更フロー：直前枠が空いていたら実行
   function extractSlotInfo(el) {
@@ -337,18 +360,31 @@
       }
 
       const now = await getServerDate().catch(() => new Date());
+      const nowMs = now.getTime();
       const sec = now.getSeconds();
-      const min = now.getMinutes();
+      const bucket = Math.floor(nowMs / 60_000);
 
-      if (lastMinute !== min) {
-        lastMinute = min;
+      if (reloadInfo.bucket !== bucket) {
+        reloadInfo = resetReloadInfo(bucket);
         reloadsThisMinute = 0;
-        log(`分が変わりました → ${now.toLocaleTimeString()} / この分のリロード残り: ${MAX_RELOADS_PER_MINUTE}`);
+      } else {
+        reloadsThisMinute = reloadInfo.count || 0;
+        if (!('loggedMinute' in reloadInfo)) {
+          reloadInfo.loggedMinute = null;
+        }
+      }
+
+      if (reloadInfo.loggedMinute !== bucket) {
+        log(`分が変わりました → ${now.toLocaleTimeString()} / この分のリロード残り: ${Math.max(0, MAX_RELOADS_PER_MINUTE - reloadsThisMinute)}`);
+        reloadInfo.loggedMinute = bucket;
+        saveReloadInfo(reloadInfo);
       }
 
       const inWindow = sec >= WINDOW_START && sec < WINDOW_END;
       if (inWindow && reloadsThisMinute < MAX_RELOADS_PER_MINUTE) {
         reloadsThisMinute++;
+        reloadInfo.count = reloadsThisMinute;
+        saveReloadInfo(reloadInfo);
         pendingReload = true;
         reloadPage(`サーバー時刻 ${sec}s（分内 ${reloadsThisMinute}/${MAX_RELOADS_PER_MINUTE}）`);
         return;
@@ -420,7 +456,7 @@
     const line = document.createElement('div');
     line.textContent = `[${new Date().toLocaleTimeString()}] ${text}`;
     logPanel.appendChild(line);
-    if (logPanel.childElementCount > 200) {
+    while (logPanel.childElementCount > 5) {
       logPanel.firstChild.remove();
     }
   }


### PR DESCRIPTION
## Summary
- persist the per-minute reload counter in session storage and reset it automatically when the minute changes
- cap the on-screen log panel to the five most recent entries

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d40a5746fc8327b43472f993fbd41f