### PR TITLE
Simplify current reservation log display

### DIFF
--- a/earlier-time.user.js
+++ b/earlier-time.user.js
@@ -430,6 +430,12 @@
   let reloadInfo = loadReloadInfo();
 
   // 予約変更フロー：直前枠が空いていたら実行
+  function extractFirstTimeText(source) {
+    if (!source) return '';
+    const match = String(source).match(SELECTORS.timePattern);
+    return match ? match[0] : '';
+  }
+
   function extractSlotInfo(el) {
     if (!el) return null;
     const text = (el.innerText || el.textContent || '').replace(/\s+/g, ' ').trim();
@@ -676,11 +682,11 @@
     const scopeLabel = describeSlotScope(currentEntry.el);
     const buttonText = currentEntry.text;
     const displayCandidates = [
-      buttonText ? buttonText.split(/\s+/)[0] : '',
       currentInfo.label,
+      extractFirstTimeText(buttonText),
       lastKnownCurrentSlot && lastKnownCurrentSlot.displayLabel,
     ].filter(Boolean);
-    const currentDisplayLabel = displayCandidates.length ? displayCandidates[0] : (currentInfo.label || '');
+    const currentDisplayLabel = displayCandidates.length ? displayCandidates[0] : '';
     const currentSignature = `${scopeSignature}|${currentDisplayLabel}`;
     const scopeMessage = scopeLabel ? `（${scopeLabel}）` : '';
     const shouldLogCurrentSlot =


### PR DESCRIPTION
## Summary
- add a helper to extract time strings from slot labels
- ensure the current reservation log displays only the time component

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4dc23b0008327b8a5503bbfbb55ae