### PR TITLE
Remove gate scope text from current slot log message

### DIFF
--- a/earlier-time.user.js
+++ b/earlier-time.user.js
@@ -688,7 +688,6 @@
     ].filter(Boolean);
     const currentDisplayLabel = displayCandidates.length ? displayCandidates[0] : '';
     const currentSignature = `${scopeSignature}|${currentDisplayLabel}`;
-    const scopeMessage = scopeLabel ? `（${scopeLabel}）` : '';
     const shouldLogCurrentSlot =
       lastLoggedCurrentSlotSignature !== currentSignature ||
       (usedStoredCurrent && !lastLoggedUsedStoredForCurrent) ||
@@ -697,7 +696,7 @@
       lastLoggedCurrentSlotSignature = currentSignature;
       lastLoggedUsedStoredForCurrent = usedStoredCurrent;
       const suffix = usedStoredCurrent ? '［保存情報から推定］' : '';
-      log(`現在の予約枠: ${currentDisplayLabel}${scopeMessage}${suffix}`);
+      log(`現在の予約枠: ${currentDisplayLabel}${suffix}`);
     } else {
       lastLoggedUsedStoredForCurrent = usedStoredCurrent;
     }


### PR DESCRIPTION
## Summary
- stop including the scope label in the "current reservation slot" log line so the gate and parking information no longer appears

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4dd7799c8832792413b03b3ec5283