### PR TITLE
Adjust reload window to start at 23 seconds

### DIFF
--- a/earlier-time-android.user.js
+++ b/earlier-time-android.user.js
@@ -50,8 +50,8 @@
   const DISPLAY_SETTLE_POLL_INTERVAL_MS = 400;
 
   // リロード許可ウィンドウ（サーバー時刻）
-  const WINDOW_START = 43; // >= 43s
-  const WINDOW_END = 53; // < 53s
+  const WINDOW_START = 23; // >= 23s
+  const WINDOW_END = 33; // < 33s
   const MAX_RELOADS_PER_MINUTE = 4;
 
   // 予約失敗時の復旧リロード 最大回数（秒に関係なく実施）

--- a/earlier-time.user.js
+++ b/earlier-time.user.js
@@ -47,8 +47,8 @@
   const DOM_POLL_INTERVAL_MS = 150;
 
   // リロード許可ウィンドウ（サーバー時刻）
-  const WINDOW_START = 43; // >= 43s
-  const WINDOW_END = 53; // < 53s
+  const WINDOW_START = 23; // >= 23s
+  const WINDOW_END = 33; // < 33s
   const MAX_RELOADS_PER_MINUTE = 4;
 
   // 予約失敗時の復旧リロード 最大回数（秒に関係なく実施）


### PR DESCRIPTION
## Summary
- shift the reload timing window to 23-33 seconds in both user script variants to match the new requirement

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dde0d4133c8327a39cac6bf5d247d0