### PR TITLE
Increase inactive slot detection log interval

### DIFF
--- a/earlier-time-android.user.js
+++ b/earlier-time-android.user.js
@@ -841,7 +841,7 @@
         setCurrentSlotDisplay('', { fallback: '未検出' });
       }
       const now = Date.now();
-      if (now - lastActiveDetectionFailureLogTime > 15_000) {
+      if (now - lastActiveDetectionFailureLogTime > 25_000) {
         lastActiveDetectionFailureLogTime = now;
         log('現在の予約枠を特定できませんでした');
         const debugSummary = entries

--- a/earlier-time.user.js
+++ b/earlier-time.user.js
@@ -793,7 +793,7 @@
         setCurrentSlotDisplay('', { fallback: '未検出' });
       }
       const now = Date.now();
-      if (now - lastActiveDetectionFailureLogTime > 15_000) {
+      if (now - lastActiveDetectionFailureLogTime > 25_000) {
         lastActiveDetectionFailureLogTime = now;
         log('現在の予約枠を特定できませんでした');
         const debugSummary = entries


### PR DESCRIPTION
## Summary
- slow down the inactive-slot detection log throttle to 25 seconds in both user scripts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dde42601248327af48e471afd816ae