### PR TITLE
Retune reload window to 15-25 second scan range

### DIFF
--- a/earlier-time-android.user.js
+++ b/earlier-time-android.user.js
@@ -50,8 +50,8 @@
   const DISPLAY_SETTLE_POLL_INTERVAL_MS = 400;
 
   // リロード許可ウィンドウ（サーバー時刻）
-  const WINDOW_START = 43; // >= 43s
-  const WINDOW_END = 53; // < 53s
+  const WINDOW_START = 15; // >= 15s
+  const WINDOW_END = 25; // < 25s
   const MAX_RELOADS_PER_MINUTE = 4;
 
   // 予約失敗時の復旧リロード 最大回数（秒に関係なく実施）
@@ -841,7 +841,7 @@
         setCurrentSlotDisplay('', { fallback: '未検出' });
       }
       const now = Date.now();
-      if (now - lastActiveDetectionFailureLogTime > 15_000) {
+      if (now - lastActiveDetectionFailureLogTime > 25_000) {
         lastActiveDetectionFailureLogTime = now;
         log('現在の予約枠を特定できませんでした');
         const debugSummary = entries

--- a/earlier-time.user.js
+++ b/earlier-time.user.js
@@ -47,8 +47,8 @@
   const DOM_POLL_INTERVAL_MS = 150;
 
   // リロード許可ウィンドウ（サーバー時刻）
-  const WINDOW_START = 43; // >= 43s
-  const WINDOW_END = 53; // < 53s
+  const WINDOW_START = 15; // >= 15s
+  const WINDOW_END = 25; // < 25s
   const MAX_RELOADS_PER_MINUTE = 4;
 
   // 予約失敗時の復旧リロード 最大回数（秒に関係なく実施）
@@ -793,7 +793,7 @@
         setCurrentSlotDisplay('', { fallback: '未検出' });
       }
       const now = Date.now();
-      if (now - lastActiveDetectionFailureLogTime > 15_000) {
+      if (now - lastActiveDetectionFailureLogTime > 25_000) {
         lastActiveDetectionFailureLogTime = now;
         log('現在の予約枠を特定できませんでした');
         const debugSummary = entries


### PR DESCRIPTION
## Summary
- retune the per-minute reload window to run between 15s and 25s in the primary userscript
- apply the same 15-25 second reload window to the Android-focused userscript

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dde42601248327af48e471afd816ae