### PR TITLE
Define missing reload limit constant

### DIFF
--- a/earlier-time.user.js
+++ b/earlier-time.user.js
@@ -54,6 +54,7 @@
 
   // 予約失敗時の復旧リロード 最大回数（秒に関係なく実施）
   const MAX_ATTEMPTS_PER_MINUTE = 3;
+  const MAX_RELOADS_PER_MINUTE = 4;
   const ATTEMPT_STORAGE_KEY = 'expo_adv_attempt_info_v3';
   const RELOAD_STORAGE_KEY = 'expo_adv_reload_info_v1';
 


### PR DESCRIPTION
## Summary
- define the missing MAX_RELOADS_PER_MINUTE constant in the desktop userscript so reload throttling logic can execute

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de03181eb083278c7115aaa2b3649f