### PR TITLE
Adjust reload window to 11-23 seconds

### DIFF
--- a/earlier-time-android.user.js
+++ b/earlier-time-android.user.js
@@ -51,8 +51,8 @@
 
   // リロード許可ウィンドウ（サーバー時刻）
 
-  const WINDOW_START = 15; // >= 15s
-  const WINDOW_END = 25; // < 25s
+  const WINDOW_START = 11; // >= 11s
+  const WINDOW_END = 23; // < 23s
 
   const MAX_RELOADS_PER_MINUTE = 4;
 

--- a/earlier-time-makeover.user.js
+++ b/earlier-time-makeover.user.js
@@ -51,8 +51,8 @@
 
   // リロード許可ウィンドウ（サーバー時刻）
 
-  const WINDOW_START = 15; // >= 15s
-  const WINDOW_END = 25; // < 25s
+  const WINDOW_START = 11; // >= 11s
+  const WINDOW_END = 23; // < 23s
 
   const MAX_RELOADS_PER_MINUTE = 4;
 

--- a/earlier-time.user.js
+++ b/earlier-time.user.js
@@ -48,8 +48,8 @@
 
   // リロード許可ウィンドウ（サーバー時刻）
 
-  const WINDOW_START = 15; // >= 15s
-  const WINDOW_END = 25; // < 25s
+  const WINDOW_START = 11; // >= 11s
+  const WINDOW_END = 23; // < 23s
 
 
   // 予約失敗時の復旧リロード 最大回数（秒に関係なく実施）


### PR DESCRIPTION
## Summary
- update the reload window start to 11 seconds and end to 23 seconds in all user scripts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de17a52c3883279a7480c11e92ceb0