### PR TITLE
Adjust reload window timing to 14-28 seconds

### DIFF
--- a/earlier-time-android.user.js
+++ b/earlier-time-android.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Expo2025 予約繰り上げ（Android版）
 // @namespace    https://github.com/expo-automation/reservation-for-an-earlier-time
-// @version      1.9
+// @version      1.10
 // @description  Android端末向けにリロードの挙動を調整した Expo2025 予約繰り上げスクリプト。現在の予約時刻より早い空き枠を自動選択し、確認モーダルまで進めて変更を完了します。失敗トースト検出時は同分内4回までリトライ。
 // @downloadURL  https://github.com/expo2025-auto/reservation-for-an-earlier-time/raw/refs/heads/main/earlier-time-android.user.js
 // @updateURL    https://github.com/expo2025-auto/reservation-for-an-earlier-time/raw/refs/heads/main/earlier-time-android.user.js
@@ -51,8 +51,8 @@
 
   // リロード許可ウィンドウ（サーバー時刻）
 
-  const WINDOW_START = 11; // >= 11s
-  const WINDOW_END = 23; // < 23s
+  const WINDOW_START = 14; // >= 14s
+  const WINDOW_END = 28; // < 28s
 
   const MAX_RELOADS_PER_MINUTE = 4;
 

--- a/earlier-time-makeover.user.js
+++ b/earlier-time-makeover.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Expo2025 予約繰り上げ（iPhone/Makeover版）
 // @namespace    https://github.com/expo-automation/reservation-for-an-earlier-time
-// @version      1.9
+// @version      1.10
 // @description  iPhone の Makeover アプリ向けにリロード挙動を最適化した Expo2025 予約繰り上げスクリプト。現在の予約時刻より早い空き枠を自動選択し、確認モーダルまで進めて変更を完了します。失敗トースト検出時は同分内4回までリトライ。
 // @downloadURL  https://github.com/expo2025-auto/reservation-for-an-earlier-time/raw/refs/heads/main/earlier-time-makeover.user.js
 // @updateURL    https://github.com/expo2025-auto/reservation-for-an-earlier-time/raw/refs/heads/main/earlier-time-makeover.user.js
@@ -51,8 +51,8 @@
 
   // リロード許可ウィンドウ（サーバー時刻）
 
-  const WINDOW_START = 11; // >= 11s
-  const WINDOW_END = 23; // < 23s
+  const WINDOW_START = 14; // >= 14s
+  const WINDOW_END = 28; // < 28s
 
   const MAX_RELOADS_PER_MINUTE = 4;
 

--- a/earlier-time.user.js
+++ b/earlier-time.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Expo2025 予約繰り上げ
 // @namespace    https://github.com/expo-automation/reservation-for-an-earlier-time
-// @version      1.9
+// @version      1.10
 // @description  現在の予約時刻より早い空き枠を自動選択し、確認モーダルまで進めて変更を完了します。失敗トースト検出時は同分内4回までリトライ。
 // @downloadURL  https://github.com/expo2025-auto/reservation-for-an-earlier-time/raw/refs/heads/main/earlier-time.user.js
 // @updateURL    https://github.com/expo2025-auto/reservation-for-an-earlier-time/raw/refs/heads/main/earlier-time.user.js
@@ -48,8 +48,8 @@
 
   // リロード許可ウィンドウ（サーバー時刻）
 
-  const WINDOW_START = 11; // >= 11s
-  const WINDOW_END = 23; // < 23s
+  const WINDOW_START = 14; // >= 14s
+  const WINDOW_END = 28; // < 28s
 
 
   // 予約失敗時の復旧リロード 最大回数（秒に関係なく実施）


### PR DESCRIPTION
## Summary
- bump the Expo2025 reservation userscripts to version 1.10
- shift the allowed reload window to start at 14 seconds and end at 28 seconds across all variants

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de381b534c8327ab67c60b2704a5d1